### PR TITLE
Add Show Self toggle

### DIFF
--- a/src/main/java/com/lou0815/PartyStatusBarsOverlay/PartyStatusBarsOverlayConfig.java
+++ b/src/main/java/com/lou0815/PartyStatusBarsOverlay/PartyStatusBarsOverlayConfig.java
@@ -33,6 +33,17 @@ public interface PartyStatusBarsOverlayConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showSelf",
+			name = "Show Self",
+			description = "Show yourself in the Overlay",
+			position = 21
+	)
+	default boolean showSelf()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 			keyName = "barGap",
 			name = "Gap Between Bars",
 			description = "How far apart the bars should be",

--- a/src/main/java/com/lou0815/PartyStatusBarsOverlay/PartyStatusBarsOverlayPlugin.java
+++ b/src/main/java/com/lou0815/PartyStatusBarsOverlay/PartyStatusBarsOverlayPlugin.java
@@ -83,13 +83,14 @@ public class PartyStatusBarsOverlayPlugin extends Plugin
 				partyService.getMembers().stream().noneMatch(member -> String.valueOf(member.getMemberId()).equals(id))
 		);
 
+		long localMemberId = partyService.getLocalMember().getMemberId();
 		for (PartyMember member : partyService.getMembers()) {
-			Long memberId = member.getMemberId();
+			long memberId = member.getMemberId();
 			PlayerStats existingStats = playerStatsMap.get(memberId);
 
 			// adding a user to the playerStatsMap if not already exists and name not <unknown>
-			if (existingStats == null && !member.getDisplayName().equals("<unknown>")) {
-
+			// If the "showSelf" flag is disabled, then add the user to the playerStatsMap if it's not the local player
+			if (existingStats == null && !member.getDisplayName().equals("<unknown>") && (config.showSelf() || memberId != localMemberId)) {
 				playerStatsMap.put(memberId, new PlayerStats(
 						memberId,
 						member.getDisplayName(),


### PR DESCRIPTION
I don't want to see myself in the party overlay, so I've added a new "Show Self" toggle.

This toggle is ON by default, to preserve existing behaviour.

# With toggle ON (default)

<img width="1231" height="179" alt="image" src="https://github.com/user-attachments/assets/5eea0147-170d-42f3-8381-17e9cfb424ff" />

# With toggle OFF

My local player "3L1F1R3" is filtered out from the overlay.

<img width="1228" height="189" alt="image" src="https://github.com/user-attachments/assets/2a2750b6-c07b-4f46-8f60-e9767d1296f4" />

